### PR TITLE
Bounded Typeclass

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "version": "1.7.0",
     "exposed-modules": [
+        "Typeclasses.Classes.Bounded",
         "Typeclasses.Classes.Comparison",
         "Typeclasses.Classes.Equality",
         "Typeclasses.Classes.Hashing",

--- a/elm.json
+++ b/elm.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "version": "1.7.0",
     "exposed-modules": [
-        "Typeclasses.Classes.Bounded",
+        "Typeclasses.Classes.Bounds",
         "Typeclasses.Classes.Comparison",
         "Typeclasses.Classes.Equality",
         "Typeclasses.Classes.Hashing",

--- a/src/Typeclasses/Classes/Bounded.elm
+++ b/src/Typeclasses/Classes/Bounded.elm
@@ -1,7 +1,7 @@
 module Typeclasses.Classes.Bounded exposing
     ( Bounded
     , bounds
-    , int, char, bool, order
+    , int, char, bool, order, unit
     , tuple2, tuple3
     )
 
@@ -20,7 +20,7 @@ module Typeclasses.Classes.Bounded exposing
 
 # Instances
 
-@docs int, char, bool, order
+@docs int, char, bool, order, unit
 
 
 # Composites
@@ -81,6 +81,13 @@ bool =
 order : Bounded Order
 order =
     bounds ( LT, GT )
+
+
+{-| Instance for `()`.
+-}
+unit : Bounded ()
+unit =
+    bounds ( (), () )
 
 
 

--- a/src/Typeclasses/Classes/Bounded.elm
+++ b/src/Typeclasses/Classes/Bounded.elm
@@ -1,6 +1,6 @@
 module Typeclasses.Classes.Bounded exposing
     ( Bounded
-    , bounds
+    , interval
     , int, char, bool, order, unit
     , tuple2, tuple3
     )
@@ -15,7 +15,7 @@ module Typeclasses.Classes.Bounded exposing
 
 # Construction utilities
 
-@docs bounds
+@docs interval
 
 
 # Instances
@@ -43,10 +43,10 @@ type alias Bounded a =
 -------------------------
 
 
-{-| Construct an instance from the upper and lower bounds.
+{-| Construct an instance from the interval `(minBound, maxBound)`.
 -}
-bounds : ( a, a ) -> Bounded a
-bounds ( minBound, maxBound ) =
+interval : ( a, a ) -> Bounded a
+interval ( minBound, maxBound ) =
     Bounded minBound maxBound
 
 
@@ -59,35 +59,35 @@ bounds ( minBound, maxBound ) =
 -}
 int : Bounded Int
 int =
-    bounds ( -2147483648, 2147483647 )
+    interval ( -2147483648, 2147483647 )
 
 
 {-| Instance for `Float`.
 -}
 char : Bounded Char
 char =
-    bounds ( '\u{0000}', '\u{10FFFF}' )
+    interval ( '\u{0000}', '\u{10FFFF}' )
 
 
 {-| Instance for `Bool`.
 -}
 bool : Bounded Bool
 bool =
-    bounds ( False, True )
+    Bounded False True
 
 
 {-| Instance for `Order`.
 -}
 order : Bounded Order
 order =
-    bounds ( LT, GT )
+    Bounded LT GT
 
 
 {-| Instance for `()`.
 -}
 unit : Bounded ()
 unit =
-    bounds ( (), () )
+    Bounded () ()
 
 
 
@@ -95,7 +95,7 @@ unit =
 -------------------------
 
 
-{-| Instance for tuple, with instances for its members provided.
+{-| Instance for tuple (pair), with instances for its members provided.
 -}
 tuple2 : Bounded a -> Bounded b -> Bounded ( a, b )
 tuple2 boundedA boundedB =
@@ -109,7 +109,7 @@ tuple2 boundedA boundedB =
     Bounded minBound maxBound
 
 
-{-| Instance for tuple, with instances for its members provided.
+{-| Instance for tuple (triple), with instances for its members provided.
 -}
 tuple3 : Bounded a -> Bounded b -> Bounded c -> Bounded ( a, b, c )
 tuple3 boundedA boundedB boundedC =

--- a/src/Typeclasses/Classes/Bounded.elm
+++ b/src/Typeclasses/Classes/Bounded.elm
@@ -33,8 +33,8 @@ module Typeclasses.Classes.Bounded exposing
 {-| Explicit typeclass which implements a bounded type `a`.
 -}
 type alias Bounded a =
-    { minBound : a
-    , maxBound : a
+    { min : a
+    , max : a
     }
 
 
@@ -101,10 +101,10 @@ tuple2 : Bounded a -> Bounded b -> Bounded ( a, b )
 tuple2 boundedA boundedB =
     let
         minBound =
-            ( boundedA.minBound, boundedB.minBound )
+            ( boundedA.min, boundedB.min )
 
         maxBound =
-            ( boundedA.maxBound, boundedB.maxBound )
+            ( boundedA.max, boundedB.max )
     in
     Bounded minBound maxBound
 
@@ -115,9 +115,9 @@ tuple3 : Bounded a -> Bounded b -> Bounded c -> Bounded ( a, b, c )
 tuple3 boundedA boundedB boundedC =
     let
         minBound =
-            ( boundedA.minBound, boundedB.minBound, boundedC.minBound )
+            ( boundedA.min, boundedB.min, boundedC.min )
 
         maxBound =
-            ( boundedA.maxBound, boundedB.maxBound, boundedC.maxBound )
+            ( boundedA.max, boundedB.max, boundedC.max )
     in
     Bounded minBound maxBound

--- a/src/Typeclasses/Classes/Bounded.elm
+++ b/src/Typeclasses/Classes/Bounded.elm
@@ -1,9 +1,8 @@
 module Typeclasses.Classes.Bounded exposing
     ( Bounded
     , bounds
-    , int, char
+    , int, char, bool, order
     , tuple2, tuple3
-    , bool
     )
 
 {-| Bounded typeclass definition and its instances for basic types.
@@ -21,7 +20,7 @@ module Typeclasses.Classes.Bounded exposing
 
 # Instances
 
-@docs int, char
+@docs int, char, bool, order
 
 
 # Composites
@@ -60,14 +59,14 @@ bounds ( minBound, maxBound ) =
 -}
 int : Bounded Int
 int =
-    bounds ( 0, 0 )
+    bounds ( -2147483648, 2147483647 )
 
 
 {-| Instance for `Float`.
 -}
 char : Bounded Char
 char =
-    bounds ( 'a', 'a' )
+    bounds ( '\u{0000}', '\u{10FFFF}' )
 
 
 {-| Instance for `Bool`.
@@ -75,6 +74,13 @@ char =
 bool : Bounded Bool
 bool =
     bounds ( False, True )
+
+
+{-| Instance for `Order`.
+-}
+order : Bounded Order
+order =
+    bounds ( LT, GT )
 
 
 

--- a/src/Typeclasses/Classes/Bounded.elm
+++ b/src/Typeclasses/Classes/Bounded.elm
@@ -62,7 +62,7 @@ int =
     interval ( -2147483648, 2147483647 )
 
 
-{-| Instance for `Float`.
+{-| Instance for `Char`.
 -}
 char : Bounded Char
 char =

--- a/src/Typeclasses/Classes/Bounded.elm
+++ b/src/Typeclasses/Classes/Bounded.elm
@@ -1,0 +1,110 @@
+module Typeclasses.Classes.Bounded exposing
+    ( Bounded
+    , bounds
+    , int, char
+    , tuple2, tuple3
+    , bool
+    )
+
+{-| Bounded typeclass definition and its instances for basic types.
+
+
+# Definition
+
+@docs Bounded
+
+
+# Construction utilities
+
+@docs bounds
+
+
+# Instances
+
+@docs int, char
+
+
+# Composites
+
+@docs tuple2, tuple3
+
+-}
+
+
+{-| Explicit typeclass which implements a bounded type `a`.
+-}
+type alias Bounded a =
+    { minBound : a
+    , maxBound : a
+    }
+
+
+
+-- * Constructors
+-------------------------
+
+
+{-| Construct an instance from the upper and lower bounds.
+-}
+bounds : ( a, a ) -> Bounded a
+bounds ( minBound, maxBound ) =
+    Bounded minBound maxBound
+
+
+
+-- * Instances
+-------------------------
+
+
+{-| Instance for `Int`.
+-}
+int : Bounded Int
+int =
+    bounds ( 0, 0 )
+
+
+{-| Instance for `Float`.
+-}
+char : Bounded Char
+char =
+    bounds ( 'a', 'a' )
+
+
+{-| Instance for `Bool`.
+-}
+bool : Bounded Bool
+bool =
+    bounds ( False, True )
+
+
+
+-- * Composites
+-------------------------
+
+
+{-| Instance for tuple, with instances for its members provided.
+-}
+tuple2 : Bounded a -> Bounded b -> Bounded ( a, b )
+tuple2 boundedA boundedB =
+    let
+        minBound =
+            ( boundedA.minBound, boundedB.minBound )
+
+        maxBound =
+            ( boundedA.maxBound, boundedB.maxBound )
+    in
+    Bounded minBound maxBound
+
+
+{-| Instance for tuple, with instances for its members provided.
+-}
+tuple3 : Bounded a -> Bounded b -> Bounded c -> Bounded ( a, b, c )
+tuple3 boundedA boundedB boundedC =
+    let
+        minBound =
+            ( boundedA.minBound, boundedB.minBound, boundedC.minBound )
+
+        maxBound =
+            ( boundedA.maxBound, boundedB.maxBound, boundedC.maxBound )
+    in
+    Bounded minBound maxBound

--- a/src/Typeclasses/Classes/Bounds.elm
+++ b/src/Typeclasses/Classes/Bounds.elm
@@ -1,16 +1,16 @@
-module Typeclasses.Classes.Bounded exposing
-    ( Bounded
+module Typeclasses.Classes.Bounds exposing
+    ( Bounds
     , interval
     , int, char, bool, order, unit
     , tuple2, tuple3
     )
 
-{-| Bounded typeclass definition and its instances for basic types.
+{-| Bounds typeclass definition and its instances for basic types.
 
 
 # Definition
 
-@docs Bounded
+@docs Bounds
 
 
 # Construction utilities
@@ -32,7 +32,7 @@ module Typeclasses.Classes.Bounded exposing
 
 {-| Explicit typeclass which implements a bounded type `a`.
 -}
-type alias Bounded a =
+type alias Bounds a =
     { min : a
     , max : a
     }
@@ -45,9 +45,9 @@ type alias Bounded a =
 
 {-| Construct an instance from the interval `(minBound, maxBound)`.
 -}
-interval : ( a, a ) -> Bounded a
+interval : ( a, a ) -> Bounds a
 interval ( minBound, maxBound ) =
-    Bounded minBound maxBound
+    Bounds minBound maxBound
 
 
 
@@ -57,37 +57,37 @@ interval ( minBound, maxBound ) =
 
 {-| Instance for `Int`.
 -}
-int : Bounded Int
+int : Bounds Int
 int =
     interval ( -2147483648, 2147483647 )
 
 
 {-| Instance for `Char`.
 -}
-char : Bounded Char
+char : Bounds Char
 char =
     interval ( '\u{0000}', '\u{10FFFF}' )
 
 
 {-| Instance for `Bool`.
 -}
-bool : Bounded Bool
+bool : Bounds Bool
 bool =
-    Bounded False True
+    Bounds False True
 
 
 {-| Instance for `Order`.
 -}
-order : Bounded Order
+order : Bounds Order
 order =
-    Bounded LT GT
+    Bounds LT GT
 
 
 {-| Instance for `()`.
 -}
-unit : Bounded ()
+unit : Bounds ()
 unit =
-    Bounded () ()
+    Bounds () ()
 
 
 
@@ -97,7 +97,7 @@ unit =
 
 {-| Instance for tuple (pair), with instances for its members provided.
 -}
-tuple2 : Bounded a -> Bounded b -> Bounded ( a, b )
+tuple2 : Bounds a -> Bounds b -> Bounds ( a, b )
 tuple2 boundedA boundedB =
     let
         minBound =
@@ -106,12 +106,12 @@ tuple2 boundedA boundedB =
         maxBound =
             ( boundedA.max, boundedB.max )
     in
-    Bounded minBound maxBound
+    Bounds minBound maxBound
 
 
 {-| Instance for tuple (triple), with instances for its members provided.
 -}
-tuple3 : Bounded a -> Bounded b -> Bounded c -> Bounded ( a, b, c )
+tuple3 : Bounds a -> Bounds b -> Bounds c -> Bounds ( a, b, c )
 tuple3 boundedA boundedB boundedC =
     let
         minBound =
@@ -120,4 +120,4 @@ tuple3 boundedA boundedB boundedC =
         maxBound =
             ( boundedA.max, boundedB.max, boundedC.max )
     in
-    Bounded minBound maxBound
+    Bounds minBound maxBound

--- a/src/Typeclasses/Classes/Bounds.elm
+++ b/src/Typeclasses/Classes/Bounds.elm
@@ -1,6 +1,5 @@
 module Typeclasses.Classes.Bounds exposing
     ( Bounds
-    , bounds
     , int, char, bool, order, unit
     , tuple2, tuple3
     )
@@ -11,11 +10,6 @@ module Typeclasses.Classes.Bounds exposing
 # Definition
 
 @docs Bounds
-
-
-# Construction utilities
-
-@docs bounds
 
 
 # Instances
@@ -39,22 +33,6 @@ type alias Bounds a =
 
 
 
--- * Constructors
--------------------------
-
-
-{-| Construct an instance from the lower and upper bounds.
-Note that the lower bound precedes the upper bound.
-
-    bounds lower upper
-
--}
-bounds : a -> a -> Bounds a
-bounds minBound maxBound =
-    Bounds minBound maxBound
-
-
-
 -- * Instances
 -------------------------
 
@@ -63,14 +41,14 @@ bounds minBound maxBound =
 -}
 int : Bounds Int
 int =
-    bounds -2147483648 2147483647
+    Bounds -2147483648 2147483647
 
 
 {-| Instance for `Char`.
 -}
 char : Bounds Char
 char =
-    bounds '\u{0000}' '\u{10FFFF}'
+    Bounds '\u{0000}' '\u{10FFFF}'
 
 
 {-| Instance for `Bool`.

--- a/src/Typeclasses/Classes/Bounds.elm
+++ b/src/Typeclasses/Classes/Bounds.elm
@@ -1,6 +1,6 @@
 module Typeclasses.Classes.Bounds exposing
     ( Bounds
-    , interval
+    , bounds
     , int, char, bool, order, unit
     , tuple2, tuple3
     )
@@ -15,7 +15,7 @@ module Typeclasses.Classes.Bounds exposing
 
 # Construction utilities
 
-@docs interval
+@docs bounds
 
 
 # Instances
@@ -43,10 +43,14 @@ type alias Bounds a =
 -------------------------
 
 
-{-| Construct an instance from the interval `(minBound, maxBound)`.
+{-| Construct an instance from the lower and upper bounds.
+Note that the lower bound precedes the upper bound.
+
+    bounds lower upper
+
 -}
-interval : ( a, a ) -> Bounds a
-interval ( minBound, maxBound ) =
+bounds : a -> a -> Bounds a
+bounds minBound maxBound =
     Bounds minBound maxBound
 
 
@@ -59,14 +63,14 @@ interval ( minBound, maxBound ) =
 -}
 int : Bounds Int
 int =
-    interval ( -2147483648, 2147483647 )
+    bounds -2147483648 2147483647
 
 
 {-| Instance for `Char`.
 -}
 char : Bounds Char
 char =
-    interval ( '\u{0000}', '\u{10FFFF}' )
+    bounds '\u{0000}' '\u{10FFFF}'
 
 
 {-| Instance for `Bool`.

--- a/src/Typeclasses/Classes/Bounds.elm
+++ b/src/Typeclasses/Classes/Bounds.elm
@@ -2,6 +2,7 @@ module Typeclasses.Classes.Bounds exposing
     ( Bounds
     , int, char, bool, order, unit
     , tuple2, tuple3
+    , map
     )
 
 {-| Bounds typeclass definition and its instances for basic types.
@@ -20,6 +21,11 @@ module Typeclasses.Classes.Bounds exposing
 # Composites
 
 @docs tuple2, tuple3
+
+
+# Instance transformation utilities
+
+@docs map
 
 -}
 
@@ -103,3 +109,20 @@ tuple3 boundedA boundedB boundedC =
             ( boundedA.max, boundedB.max, boundedC.max )
     in
     Bounds minBound maxBound
+
+
+
+-- * Transformations
+-------------------------
+
+
+{-| Map over the owner type of an instance to produce a new instance.
+
+For example, to created a bounded record type:
+
+    map (\v -> { x = v }) int == Bounds { x = int.min } { x = int.max }
+
+-}
+map : (a -> b) -> Bounds a -> Bounds b
+map transform boundsA =
+    Bounds (transform boundsA.min) (transform boundsA.max)

--- a/src/Typeclasses/Classes/Bounds.elm
+++ b/src/Typeclasses/Classes/Bounds.elm
@@ -118,7 +118,7 @@ tuple3 boundedA boundedB boundedC =
 
 {-| Map over the owner type of an instance to produce a new instance.
 
-For example, to created a bounded record type:
+For example, to create a bounded record type:
 
     map (\v -> { x = v }) int == Bounds { x = int.min } { x = int.max }
 


### PR DESCRIPTION
Add a Bounded typeclass to represent types with a minimum and maximum value. 

The following instances have been included:

+ `Int`
+ `Char`
+ `Bool`
+ `Order`
+ `()`

Bounded pairs and triples can be derived from the member types, provided they are themselves bounded.